### PR TITLE
Bare minimum functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +123,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "memchr"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "mio"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc250d6848c90d719ea2ce34546fb5df7af1d3fd189d10bf7bad80bfcebecd95"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,10 +189,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
 name = "os_str_bytes"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "proc-macro-error"
@@ -165,6 +279,48 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -200,6 +356,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "tokio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 clap = "3.0.0-beta.2"
 num_cpus = "1.0"
+tokio = { version = "1", features = [ "full" ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,25 +43,47 @@ impl Each {
         }
     }
 
-    pub async fn run(self) -> io::Result<()> {
+    pub async fn run(&self) -> io::Result<()> {
         // TODO(jml): Figure out how to separate 'iterate through files' from 'process files'.
 
         // TODO(jml): Currently retrieving each file in sequence, and then
         // running each command and waiting for each command. Need instead to
         // run things in parallel.
-        let mut source_dir = fs::read_dir(self.source_dir).await?;
+        let mut source_dir = fs::read_dir(&self.source_dir).await?;
         while let Some(source_file) = source_dir.next_entry().await? {
             let metadata = source_file.metadata().await?;
             if metadata.is_file() {
                 // TODO(jml): Either format the command or pass stdin.
                 let path = source_file.path();
+                println!("path: {:?}", path);
                 // TODO(jml): Understand whether this actually has any benefit over directly opening the standard file.
                 let async_file = fs::File::open(path).await?;
-                let std_file = async_file.into_std().await;
+                let in_file = async_file.into_std().await;
+
+                let mut base_directory = self.destination_dir.clone();
+                base_directory.push(source_file.file_name());
+                println!("creating base directory: {:?}", base_directory);
+                // TODO(jml): Instead of looking before leaping, check the error and only re-raise if file exists.
+                if !base_directory.exists() {
+                    // TODO(jml): create_dir_all is probably inefficient,
+                    // since we can probably assume that the destination directory exists.
+                    fs::create_dir_all(&base_directory).await?;
+                }
+                println!("Base directory created");
+                let mut out_path = base_directory.clone();
+                out_path.push("out");
+                // TODO(jml): 'create' truncates. Actual desired behaviour depends on 'recreate' setting.
+                let out_file = fs::File::create(out_path).await?.into_std().await;
+                let mut err_path = base_directory.clone();
+                err_path.push("err");
+                let err_file = fs::File::create(err_path).await?.into_std().await;
+
                 let mut child_process = Command::new(&self.shell)
                     .arg("-c")
                     .arg(&self.command)
-                    .stdin(std_file)
+                    .stdin(in_file)
+                    .stdout(out_file)
+                    .stderr(err_file)
                     .spawn()?;
                 child_process.wait().await?;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,10 @@ impl Each {
     pub async fn run(self) -> io::Result<()> {
         let mut source_dir = fs::read_dir(self.source_dir).await?;
         while let Some(child) = source_dir.next_entry().await? {
-            println!("{:?}", child.path());
+            let metadata = child.metadata().await?;
+            if metadata.is_file() {
+                println!("{:?}", child.path());
+            }
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,6 @@ pub struct Each {
     source_dir: PathBuf,
     command: String,
     destination_dir: PathBuf,
-    num_processes: usize,
-    recreate: bool,
-    retries: u32,
     shell: String,
 }
 
@@ -27,18 +24,15 @@ impl Each {
         source_dir: PathBuf,
         command: String,
         destination_dir: PathBuf,
-        num_processes: usize,
-        recreate: bool,
-        retries: u32,
+        _num_processes: usize,
+        _recreate: bool,
+        _retries: u32,
         shell: String,
     ) -> Self {
         Each {
             source_dir,
             command,
             destination_dir,
-            num_processes,
-            recreate,
-            retries,
             shell,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+use std::io;
 use std::path::PathBuf;
 use std::str::FromStr;
+use tokio::fs;
 
 #[derive(Debug)]
 pub struct Each {
@@ -38,6 +40,14 @@ impl Each {
             retries,
             shell,
         }
+    }
+
+    pub async fn run(self) -> io::Result<()> {
+        let mut source_dir = fs::read_dir(self.source_dir).await?;
+        while let Some(child) = source_dir.next_entry().await? {
+            println!("{:?}", child.path());
+        }
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,21 +55,18 @@ impl Each {
             if metadata.is_file() {
                 // TODO(jml): Either format the command or pass stdin.
                 let path = source_file.path();
-                println!("path: {:?}", path);
                 // TODO(jml): Understand whether this actually has any benefit over directly opening the standard file.
                 let async_file = fs::File::open(path).await?;
                 let in_file = async_file.into_std().await;
 
                 let mut base_directory = self.destination_dir.clone();
                 base_directory.push(source_file.file_name());
-                println!("creating base directory: {:?}", base_directory);
                 // TODO(jml): Instead of looking before leaping, check the error and only re-raise if file exists.
                 if !base_directory.exists() {
                     // TODO(jml): create_dir_all is probably inefficient,
                     // since we can probably assume that the destination directory exists.
                     fs::create_dir_all(&base_directory).await?;
                 }
-                println!("Base directory created");
                 let mut out_path = base_directory.clone();
                 out_path.push("out");
                 // TODO(jml): 'create' truncates. Actual desired behaviour depends on 'recreate' setting.

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,16 +78,16 @@ async fn main() -> Result<(), io::Error> {
             dest
         }
     };
-    let processes = opts.processes.unwrap_or(num_cpus::get());
+    let num_processes = opts.processes.unwrap_or(num_cpus::get());
     let each = Each::new(
         opts.source,
         opts.command,
         destination,
-        processes,
+        num_processes,
         opts.recreate,
         opts.retries,
         opts.shell,
     );
     println!("Opts: {:?}", each);
-    Ok(())
+    each.run().await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@ async fn main() -> Result<(), io::Error> {
             dest
         }
     };
+    // TODO(jml): Use shellexpand on input directories
     let num_processes = opts.processes.unwrap_or(num_cpus::get());
     let each = Each::new(
         opts.source,

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,8 @@ struct Opts {
     input_mode: Option<InputMode>,
 }
 
-fn main() -> Result<(), io::Error> {
+#[tokio::main]
+async fn main() -> Result<(), io::Error> {
     let opts: Opts = Opts::parse();
     // TODO: Nicer error for invalid file name
     let source = opts.source.canonicalize()?;


### PR DESCRIPTION
This version of `reach` will run one process per file in a directory. It will run the processes in sequence, and pass the contents of the file as stdin on the spawned processes.

Essentially, it's an overcomplex `for` loop. 