### PR TITLE
Fix broken integration tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19,7 +19,7 @@ where
 {
     reach::Config {
         command: command.into(),
-        shell: env::var("SHELL").unwrap(),
+        shell: env::var("SHELL").unwrap_or(String::from("/bin/sh")),
         source_dir: source_dir.into(),
         destination_dir: dest_dir.into(),
         input_mode,


### PR DESCRIPTION
The integration tests assumed that `SHELL` would be set in the environment. In our CI, it is not set. 

Therefore, choose `/bin/sh` as a sensible default.