### PR TITLE
Add a progress bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,9 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
+ "regex",
  "terminal_size",
+ "unicode-width",
  "winapi",
 ]
 
@@ -451,6 +453,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "clap",
+ "console",
  "futures",
  "indicatif",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +238,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +335,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -415,6 +452,7 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "indicatif",
  "num_cpus",
  "tempfile",
  "tokio",
@@ -429,6 +467,21 @@ checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -515,6 +568,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.52"
 clap = "3.0.0-beta.2"
+console = "0.15.0"
 futures = "0.3"
 indicatif = "0.16.2"
 num_cpus = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 async-trait = "0.1.52"
 clap = "3.0.0-beta.2"
 futures = "0.3"
+indicatif = "0.16.2"
 num_cpus = "1.0"
 tokio = { version = "1", features = [ "full" ] }
 tokio-stream = { version = "0.1", features = [ "fs" ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,11 +69,11 @@ impl Each {
                 Ok((source_file, metadata))
             })
             .try_filter_map(|(source_file, metadata)| async move {
-                if metadata.is_file() {
-                    Ok(Some(source_file))
+                Ok(if metadata.is_file() {
+                    Some(source_file)
                 } else {
-                    Ok(None)
-                }
+                    None
+                })
             })
             .try_for_each_concurrent(self.num_processes, |source_file| async move {
                 let result = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 use async_trait::async_trait;
-use futures::stream::TryStreamExt;
+use futures::stream;
+use indicatif::ProgressBar;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::process::ExitStatus;
 use std::str::FromStr;
 use tokio::fs;
 use tokio::process::Command;
@@ -45,8 +48,6 @@ struct Each {
     num_processes: usize,
 }
 
-// TODO: Add progress bar
-
 // TODO: Add support for source "dir" being a filename with a bunch of lines.
 // Consider instead making a separate command that turns a filename with a
 // bunch of lines into a bunch of directories with the lines as contents.
@@ -59,13 +60,13 @@ impl Each {
         }
     }
 
-    async fn run<R: Runner>(&self, runner: &R, destination_dir: &Path) -> io::Result<()> {
+    async fn load_files(&self) -> io::Result<Vec<fs::DirEntry>> {
+        use stream::TryStreamExt;
         let source_dir = fs::read_dir(&self.source_dir).await?;
         let stream = ReadDirStream::new(source_dir);
         stream
             .and_then(|source_file| async move {
                 let metadata = source_file.metadata().await?;
-                println!("metadata: {:?}", metadata);
                 Ok((source_file, metadata))
             })
             .try_filter_map(|(source_file, metadata)| async move {
@@ -75,18 +76,32 @@ impl Each {
                     None
                 })
             })
-            .try_for_each_concurrent(self.num_processes, |source_file| async move {
+            .try_collect()
+            .await
+    }
+
+    async fn run<R: Runner>(&self, runner: &R, destination_dir: &Path) -> io::Result<()> {
+        use stream::StreamExt;
+        let source_files = self.load_files().await?;
+        let progress_bar = ProgressBar::new(source_files.len() as u64);
+        let progress_bar = Pin::new(&progress_bar);
+        stream::iter(source_files.into_iter())
+            .for_each_concurrent(self.num_processes, |source_file| async move {
                 let result = self
                     .run_command(runner, &source_file, destination_dir)
                     .await;
-                println!(
-                    "run_command for {:?}: {:?}",
-                    source_file.file_name(),
-                    result
-                );
-                result
+                // TODO(jml): Actually use `result` to communicate whether the run succeeded.
+                // TODO(jml): Add some styling to get more useful progress information.
+                // TODO(jml): Hide or suppress the progress bar in tests.
+                match result {
+                    Ok(_) => progress_bar.inc(1),
+                    Err(e) => {
+                        progress_bar.println(format!("Error: {:?}", e));
+                        progress_bar.inc(1);
+                    }
+                }
             })
-            .await?;
+            .await;
         Ok(())
     }
 
@@ -95,7 +110,7 @@ impl Each {
         runner: &R,
         source_file: &fs::DirEntry,
         destination_dir: &Path,
-    ) -> io::Result<()> {
+    ) -> io::Result<ExitStatus> {
         // TODO(jml): This function has potential for internal parallelism.
         // Better understand how join! and .await work and see if there's any benefit.
         let base_directory = destination_dir.join(source_file.file_name());
@@ -111,8 +126,7 @@ impl Each {
 
         let mut command = runner.get_command(source_file).await?;
         let mut child_process = command.stdout(out_file).stderr(err_file).spawn()?;
-        child_process.wait().await?;
-        Ok(())
+        child_process.wait().await
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,5 +135,6 @@ fn ensure_destination_directory(destination: PathBuf) -> Result<PathBuf, clap::E
 async fn main() -> Result<(), io::Error> {
     let opts: Opts = Opts::parse();
     let config = parse_options(opts).unwrap_or_else(|err| err.exit());
-    reach::run(config).await
+    let progress_bar = reach::default_progress_bar();
+    reach::run(config, progress_bar).await
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,40 @@
+use indicatif::ProgressBar;
+use std::io;
+use std::process::ExitStatus;
+
+/// How `reach` reports progress.
+///
+/// Exists so we can have a "real" implementation that delegates to indicatif,
+/// and a "fake" implementation that does nothing and is used only in tests.
+pub trait Progress {
+    fn set_num_tasks(&self, tasks: usize);
+    fn task_completed(&self, result: io::Result<ExitStatus>);
+}
+
+impl Progress for ProgressBar {
+    fn set_num_tasks(&self, tasks: usize) {
+        self.set_length(tasks as u64);
+    }
+
+    fn task_completed(&self, result: io::Result<ExitStatus>) {
+        // TODO(jml): Actually use `result` to communicate whether the run succeeded.
+        // TODO(jml): Add some styling to get more useful progress information.
+        match result {
+            Ok(_) => self.inc(1),
+            Err(e) => {
+                self.println(format!("Error: {:?}", e));
+                self.inc(1);
+            }
+        }
+    }
+}
+
+impl Progress for () {
+    fn set_num_tasks(&self, _tasks: usize) {}
+    fn task_completed(&self, _result: io::Result<ExitStatus>) {}
+}
+
+/// Construct a real progress bar for rendering to users.
+pub fn default_progress_bar() -> impl Progress {
+    ProgressBar::new(0)
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,3 +1,4 @@
+use console::Emoji;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::io;
 use std::process::ExitStatus;
@@ -11,17 +12,20 @@ pub trait Progress {
     fn task_completed(&self, result: io::Result<ExitStatus>);
 }
 
+static OK: Emoji<'_, '_> = Emoji("✅", "OK");
+static ERROR: Emoji<'_, '_> = Emoji("❌", "ERROR");
+
 impl Progress for ProgressBar {
     fn set_num_tasks(&self, tasks: usize) {
         self.set_length(tasks as u64);
     }
 
     fn task_completed(&self, result: io::Result<ExitStatus>) {
-        // TODO(jml): Actually use `result` to communicate whether the run succeeded.
         match result {
             Ok(_) => self.inc(1),
             Err(e) => {
                 self.println(format!("Error: {:?}", e));
+                self.set_prefix(format!("{} ", ERROR));
                 self.inc(1);
             }
         }
@@ -35,8 +39,10 @@ impl Progress for () {
 
 /// Construct a real progress bar for rendering to users.
 pub fn default_progress_bar() -> impl Progress {
-    ProgressBar::new(0).with_style(
-        ProgressStyle::default_bar()
-            .template("{prefix}{wide_bar} {pos}/{len} [{elapsed}<{eta}, {per_sec}]"),
-    )
+    ProgressBar::new(0)
+        .with_style(
+            ProgressStyle::default_bar()
+                .template("{prefix}{wide_bar} {pos}/{len} [{elapsed}<{eta}, {per_sec}]"),
+        )
+        .with_prefix(format!("{} ", OK))
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,4 +1,4 @@
-use indicatif::ProgressBar;
+use indicatif::{ProgressBar, ProgressStyle};
 use std::io;
 use std::process::ExitStatus;
 
@@ -18,7 +18,6 @@ impl Progress for ProgressBar {
 
     fn task_completed(&self, result: io::Result<ExitStatus>) {
         // TODO(jml): Actually use `result` to communicate whether the run succeeded.
-        // TODO(jml): Add some styling to get more useful progress information.
         match result {
             Ok(_) => self.inc(1),
             Err(e) => {
@@ -36,5 +35,8 @@ impl Progress for () {
 
 /// Construct a real progress bar for rendering to users.
 pub fn default_progress_bar() -> impl Progress {
-    ProgressBar::new(0)
+    ProgressBar::new(0).with_style(
+        ProgressStyle::default_bar()
+            .template("{prefix}{wide_bar} {pos}/{len} [{elapsed}<{eta}, {per_sec}]"),
+    )
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -53,12 +53,15 @@ where
 async fn test_stdin_empty() -> io::Result<()> {
     let source = tempfile::tempdir()?;
     let destination = tempfile::tempdir()?;
-    reach::run(new_test_config(
-        "cat",
-        source.path(),
-        destination.path(),
-        reach::InputMode::Stdin,
-    ))
+    reach::run(
+        new_test_config(
+            "cat",
+            source.path(),
+            destination.path(),
+            reach::InputMode::Stdin,
+        ),
+        (),
+    )
     .await
 }
 
@@ -76,12 +79,15 @@ async fn test_stdin() -> io::Result<()> {
     ])?;
 
     let destination = tempfile::tempdir()?;
-    reach::run(new_test_config(
-        "cat",
-        source.path(),
-        destination.path(),
-        reach::InputMode::Stdin,
-    ))
+    reach::run(
+        new_test_config(
+            "cat",
+            source.path(),
+            destination.path(),
+            reach::InputMode::Stdin,
+        ),
+        (),
+    )
     .await?;
 
     let destination_path = destination.path();
@@ -126,12 +132,15 @@ async fn test_filename() -> io::Result<()> {
     ])?;
 
     let destination = tempfile::tempdir()?;
-    reach::run(new_test_config(
-        "echo -n {}",
-        source.path(),
-        destination.path(),
-        reach::InputMode::Filename,
-    ))
+    reach::run(
+        new_test_config(
+            "echo -n {}",
+            source.path(),
+            destination.path(),
+            reach::InputMode::Filename,
+        ),
+        (),
+    )
     .await?;
 
     let destination_path = destination.path();


### PR DESCRIPTION
This is an initial implementation that lacks deep consideration of UX. It's also missing the funky prediction time that @DRMacIver has in `each`. 

I'm not hugely happy with constructing the progress bar with a 0 size. Nor am I happy with the way the progress bar is parametrized in order to enable tests. 

I spent a lot of energy learning about how to use a progress bar within an `async move` loop—see https://github.com/jml/indicatif-read-dir-stream/blob/main/src/main.rs for details. The right answer (pinning) turned out to be irrelevant.